### PR TITLE
Fix minor formatting to pass pre-commit formatting check for toml

### DIFF
--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "{{projectname}}"
 description = "{{description}}"
-authors= [{ name = "Scipp contributors" }]
+authors = [{ name = "Scipp contributors" }]
 license = { file = "LICENSE" }
 readme = "README.md"
 classifiers = [

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "{{projectname}}"
 description = "{{description}}"
-authors= [{name="Scipp contributors"}]
+authors= [{ name = "Scipp contributors" }]
 license = { file = "LICENSE" }
 readme = "README.md"
 classifiers = [


### PR DESCRIPTION
It complained when I committed `pyproject.toml` with updates in the beamlime
due to `authors=[{name="Scipp contributors"}]` since it didn't have spaces between key and the value ...?