### PR TITLE
Update black hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,8 +17,8 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
-  - repo: https://github.com/psf/black
-    rev: 23.1.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.9.0
     hooks:
       - id: black
   - repo: https://github.com/kynan/nbstripout


### PR DESCRIPTION
Update version and use official mirror. According to the release notes, using this mirror is up to 2x faster.