### PR TITLE
Fix docs build after broken by #28

### DIFF
--- a/.github/workflows/ci.yml.jinja
+++ b/.github/workflows/ci.yml.jinja
@@ -41,10 +41,11 @@ jobs:
       os-variant: ${{ matrix.os }}
       python-version: ${{ matrix.python.version }}
       tox-env: ${{ matrix.python.tox-env }}
-{% endraw %}
 
   docs:
     needs: tests
     uses: ./.github/workflows/docs.yml
     with:
       publish: false
+      branch: ${{ github.head_ref == '' && github.ref_name || github.head_ref }}
+{% endraw %}


### PR DESCRIPTION
Somehow this line was simply removed in #28, I don't know why. Without it the builds don't work.