### PR TITLE
Support nightly scipp from release asset

### DIFF
--- a/requirements/make_base.py
+++ b/requirements/make_base.py
@@ -1,6 +1,6 @@
+import sys
 from argparse import ArgumentParser
 
-import sys
 import tomli
 
 parser = ArgumentParser()
@@ -28,7 +28,7 @@ with open("base.in", "w") as f:
 
 def as_nightly(name: str) -> str:
     if name == "scipp":
-        version = f"py{sys.version_info.major}{sys.version_info.minor}"
+        version = f"cp{sys.version_info.major}{sys.version_info.minor}"
         base = "https://github.com/scipp/scipp/releases/download/nightly/scipp-nightly"
         suffix = "manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
         return "-".join([base, version, version, suffix])

--- a/requirements/make_base.py
+++ b/requirements/make_base.py
@@ -1,5 +1,6 @@
 from argparse import ArgumentParser
 
+import sys
 import tomli
 
 parser = ArgumentParser()
@@ -27,7 +28,10 @@ with open("base.in", "w") as f:
 
 def as_nightly(name: str) -> str:
     if name == "scipp":
-        return "https://github.com/scipp/scipp/releases/download/nightly/scipp-nightly-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"  # noqa: E501
+        version = f"py{sys.version_info.major}{sys.version_info.minor}"
+        base = "https://github.com/scipp/scipp/releases/download/nightly/scipp-nightly"
+        suffix = "manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        return "-".join([base, version, version, suffix])
     return f"{name} @ git+https://github.com/scipp/{name}@main"
 
 

--- a/requirements/make_base.py
+++ b/requirements/make_base.py
@@ -24,9 +24,16 @@ with open("base.in", "w") as f:
     f.write(header)
     f.write("\n".join(dependencies))
 
+
+def as_nightly(name: str) -> str:
+    if name == "scipp":
+        return "https://github.com/scipp/scipp/releases/download/nightly/scipp-nightly-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"  # noqa: E501
+    return f"{name} @ git+https://github.com/scipp/{name}@main"
+
+
 nightly = args.nightly.split(",")
 dependencies = [dep for dep in dependencies if not dep.startswith(tuple(nightly))]
-dependencies += [f"{arg} @ git+https://github.com/scipp/{arg}@main" for arg in nightly]
+dependencies += [as_nightly(arg) for arg in nightly]
 
 with open("nightly.in", "w") as f:
     f.write(header)


### PR DESCRIPTION
This uses the releases that scipp/scipp#3290 is attaching as release assets.