### PR TITLE
Move to pyproject toml

### DIFF
--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-  "setuptools>=67",
-  "setuptools_scm[toml]>=7.0",
+  "setuptools>=68",
+  "setuptools_scm[toml]>=8.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.cfg.jinja
+++ b/setup.cfg.jinja
@@ -1,15 +1,3 @@
-[options]
-package_dir =
-    = src
-packages = find:
-include_package_data = True
-
-[options.packages.find]
-where = src
-
-[options.package_data]
-{{projectname}} = py.typed
-
 [flake8]
 # See https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length
 max-line-length = 88

--- a/tox.ini.jinja
+++ b/tox.ini.jinja
@@ -53,7 +53,9 @@ commands = python -m mypy .
 
 [testenv:deps]
 description = Update dependencies by running pip-compile-multi
-deps = pip-compile-multi
+deps =
+  pip-compile-multi
+  tomli
 skip_install = true
 changedir = requirements
 commands = python ./make_base.py --nightly {{nightly_deps}}


### PR DESCRIPTION
Fixes #36 

Note that this is based on #46 

This changes behaviour for data files (like `py.typed`). They are now included in the source dist and wheel iff they are tracked by git. So when making a new package and testing the wheel build. We need to first add and commit those files to git.