### PR TITLE
Define related projects in template, add docs links

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -21,3 +21,9 @@ nightly_deps:
     List of dependencies to install from Git during nightly builds,
     separated by commas. Make sure to also list transitive dependencies,
     otherwise their released versions will be used.
+related_projects:
+  type: str
+  help: |
+    List of related projects, separated by commas.
+    This will be used to generate a list of links in the documentation.
+    For example, "Scipp,Sciline,Plopp".

--- a/docs/conf.py.jinja
+++ b/docs/conf.py.jinja
@@ -122,14 +122,17 @@ html_theme_options = {
     "primary_sidebar_end": ["edit-this-page", "sourcelink"],
     "secondary_sidebar_items": [],
     "show_nav_level": 1,
-    "header_links_before_dropdown": 4,
+    "header_links_before_dropdown": 4,  # Adjust this to ensure external links are moved to "Move" menu
     "pygment_light_style": "github-light-high-contrast",
     "pygment_dark_style": "github-dark-high-contrast",
     "logo": {
         "image_light": "_static/logo.svg",
         "image_dark": "_static/logo-dark.svg",
     },
-    "external_links": [],
+    "external_links": [
+        {% for link in related_projects.replace(' ', '').split(',')|sort -%}
+            {"name": "{{ link }}", "url": "https://scipp.github.io{% if link == 'Scipp' %}{% else %}/{{ link|lower }}{% endif %}"},
+        {% endfor %}],
     "icon_links": [
         {
             "name": "GitHub",


### PR DESCRIPTION
Fixes #50. Like in Plopp, this will overflow to the "More" menu. Will need to adjust the overflow limit, depending on the number of other docs sections used in a project.