### PR TITLE
Generalize Nightly setup for non-scipp GitHub organizations

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -18,9 +18,12 @@ year: 2023
 nightly_deps:
   type: str
   help: |
-    List of dependencies to install from Git during nightly builds,
+    List of dependencies to install from GitHub during nightly builds,
     separated by commas. Make sure to also list transitive dependencies,
-    otherwise their released versions will be used.
+    otherwise their released versions will be used. Specify either a
+    repository name or 'org/repo'. If no organization is given it defaults
+    to 'scipp'. In either case, the 'main' branch will be used. Example:
+        scipp,sciline,dask/dask
 related_projects:
   type: str
   help: |

--- a/requirements/make_base.py
+++ b/requirements/make_base.py
@@ -26,13 +26,17 @@ with open("base.in", "w") as f:
     f.write("\n".join(dependencies))
 
 
-def as_nightly(name: str) -> str:
-    if name == "scipp":
+def as_nightly(repo: str) -> str:
+    if "/" in repo:
+        org, repo = repo.split("/")
+    else:
+        org = "scipp"
+    if repo == "scipp":
         version = f"cp{sys.version_info.major}{sys.version_info.minor}"
         base = "https://github.com/scipp/scipp/releases/download/nightly/scipp-nightly"
         suffix = "manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
         return "-".join([base, version, version, suffix])
-    return f"{name} @ git+https://github.com/scipp/{name}@main"
+    return f"{repo} @ git+https://github.com/{org}/{repo}@main"
 
 
 nightly = args.nightly.split(",") if args.nightly else []


### PR DESCRIPTION
We can use this, e.g., to test Sciline against `dask/dask@main`.