### PR TITLE
Add nightly workflow for testing at latest release

### DIFF
--- a/.github/workflows/nightly_at_main.yml
+++ b/.github/workflows/nightly_at_main.yml
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
-name: Nightly tests at latest release
+name: Nightly test at main branch
 
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 23 * * *'
+    - cron: '30 23 * * *'
 
 jobs:
   setup:
@@ -14,14 +14,8 @@ jobs:
     runs-on: 'ubuntu-20.04'
     outputs:
       min_python: ${{ steps.vars.outputs.min_python }}
-      release_tag: ${{ steps.release.outputs.release_tag }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # history required so we can determine latest release tag
-      - name: Get last release tag from git
-        id: release
-        run: echo "release_tag=$(git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*')" >> $GITHUB_OUTPUT
       - name: Get Python version for other CI jobs
         id: vars
         run: echo "min_python=$(cat .github/workflows/python-version-ci)" >> $GITHUB_OUTPUT
@@ -40,4 +34,3 @@ jobs:
       os-variant: ${{ matrix.os }}
       python-version: ${{ matrix.python.version }}
       tox-env: ${{ matrix.python.tox-env }}
-      checkout_ref: ${{ needs.setup.outputs.release_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-          fetch-depth: 0  # history required so cmake can determine version
+          fetch-depth: 0  # history required so setuptools_scm can determine version
 
       - uses: mamba-org/setup-micromamba@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ on:
       coverage-report:
         default: false
         type: boolean
+      checkout_ref:
+        default: ''
+        type: string
   workflow_call:
     inputs:
       os-variant:
@@ -36,6 +39,9 @@ on:
       coverage-report:
         default: false
         type: boolean
+      checkout_ref:
+        default: ''
+        type: string
 
 jobs:
   test:
@@ -43,6 +49,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.checkout_ref }}
       - uses: actions/setup-python@v3
         with:
           python-version: ${{ inputs.python-version }}


### PR DESCRIPTION
This is in addition to the test at `main`.

Note that the workflow will fail until we have made the first release that contains the Nightly tox setup.