### PR TITLE
Python 3.12 breaks anaconda upload due to removal of 'imp'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,8 +84,10 @@ jobs:
       - uses: mamba-org/setup-micromamba@v1
         with:
           environment-name: upload-env
+          # frozen python due to breaking removal of 'imp' in 3.12
           create-args: >-
             anaconda-client
+            python=3.11
       - run: anaconda --token ${{ secrets.ANACONDATOKEN }} upload --user scipp --label main $(ls conda-package-noarch/*.tar.bz2)
 
   docs:


### PR DESCRIPTION
Found in `esssans`, shown that this works in https://github.com/scipp/esssans/actions/runs/6587736754