### PR TITLE
Run nightly builds only on weekdays

### DIFF
--- a/.github/workflows/nightly_at_main.yml
+++ b/.github/workflows/nightly_at_main.yml
@@ -6,7 +6,7 @@ name: Nightly test at main branch
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 23 * * *'
+    - cron: '30 1 * * 1-5'
 
 jobs:
   setup:

--- a/.github/workflows/nightly_at_release.yml
+++ b/.github/workflows/nightly_at_release.yml
@@ -6,7 +6,7 @@ name: Nightly tests at latest release
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 23 * * *'
+    - cron: '0 1 * * 1-5'
 
 jobs:
   setup:


### PR DESCRIPTION
This will reduce notifications spam somewhat.

Choose to run early in the morning we we have fresh info when we come to work, instead of, e.g., potentially stale info from Friday night