### PR TITLE
fix: allow positional arguments to pytest

### DIFF
--- a/tox.ini.jinja
+++ b/tox.ini.jinja
@@ -6,7 +6,7 @@ isolated_build = true
 deps = -r requirements/test.txt
 setenv =
   JUPYTER_PLATFORM_DIRS = 1
-commands = pytest
+commands = pytest {posargs}
 
 [testenv:nightly]
 deps =


### PR DESCRIPTION
It's useful to be able to pass arguments to pytest when running tests through tox.
For example, running only a subset of the tests, changing verbosity, or printing stdout.

With the `{posargs}` placeholder all argument to `tox` after `--` will replace the placeholder.