### PR TITLE
Add known_fist_party isort config

### DIFF
--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -58,6 +58,7 @@ skip-string-normalization = true
 [tool.isort]
 skip_gitignore = true
 profile = "black"
+known_first_party = ["{{projectname}}"]
 
 [tool.mypy]
 strict = true


### PR DESCRIPTION
E.g., in `sciline`, this will make it so that `import sciline` is sorted like `from . import` instead of treating it as a 3rd party import.