### PR TITLE
Use a _version.py file instead of setuptools.meta

### DIFF
--- a/.gitignore.jinja
+++ b/.gitignore.jinja
@@ -3,6 +3,12 @@ html
 .tox
 src/{{projectname}}.egg-info
 
+{% if namespace_package -%}
+src/{{namespace_package}}/{{projectname.removeprefix(namespace_package)}}/_version.py
+{% else %}
+src/{{projectname}}/_version.py
+{% endif %}
+
 *.sw?
 
 .clangd/

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -39,6 +39,11 @@ dynamic = ["version"]
 "Source" = "https://github.com/{{orgname}}/{{projectname}}"
 
 [tool.setuptools_scm]
+{% if namespace_package -%}
+write_to = "src/{{namespace_package}}/{{projectname.removeprefix(namespace_package)}}/_version.py"
+{% else %}
+write_to = "src/{{projectname}}/_version.py"
+{% endif %}
 
 [tool.pytest.ini_options]
 minversion = "7.0"

--- a/src/{% if namespace_package %}{{namespace_package}}{% endif %}/{{ projectname.removeprefix(namespace_package) }}/__init__.py.jinja
+++ b/src/{% if namespace_package %}{{namespace_package}}{% endif %}/{{ projectname.removeprefix(namespace_package) }}/__init__.py.jinja
@@ -1,12 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) {{year}} {{orgname|capitalize}} contributors (https://github.com/{{orgname}})
 
-# flake8: noqa
-import importlib.metadata
-
-try:
-    __version__ = importlib.metadata.version(__package__ or __name__)
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "0.0.0"
-
-del importlib
+from ._version import __version__, __version_tuple__

--- a/src/{% if not namespace_package %}{{projectname}}{% endif %}/__init__.py.jinja
+++ b/src/{% if not namespace_package %}{{projectname}}{% endif %}/__init__.py.jinja
@@ -1,12 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) {{year}} {{orgname|capitalize}} contributors (https://github.com/{{orgname}})
 
-# flake8: noqa
-import importlib.metadata
-
-try:
-    __version__ = importlib.metadata.version(__package__ or __name__)
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "0.0.0"
-
-del importlib
+from ._version import __version__, __version_tuple__

--- a/tests/package_test.py.jinja
+++ b/tests/package_test.py.jinja
@@ -5,3 +5,4 @@ import {{projectname}} as pkg
 
 def test_has_version():
     assert hasattr(pkg, '__version__')
+    assert hasattr(pkg, '__version_tuple__')


### PR DESCRIPTION
Fixes #59

We could of course parse the tuple from `__version__` but this approach seems more robust.