### PR TITLE
Remove autodoc_pydantic dep

### DIFF
--- a/template/requirements/docs.in
+++ b/template/requirements/docs.in
@@ -1,5 +1,4 @@
 -r base.in
-autodoc_pydantic
 ipykernel
 ipython!=8.7.0  # Breaks syntax highlighting in Jupyter code cells.
 myst-parser


### PR DESCRIPTION
I guess this was copied over from Scitacean. We don't use pydantic, so there is no reason to include this.