### PR TITLE
Fix import order

### DIFF
--- a/template/requirements/make_base.py
+++ b/template/requirements/make_base.py
@@ -1,7 +1,7 @@
 import sys
 from argparse import ArgumentParser
-from typing import List
 from pathlib import Path
+from typing import List
 
 import tomli
 


### PR DESCRIPTION
Introduced in #98. I forgot that we don't run isort on these files in the template. But it did run in a rendered project and complained about the order of imports.