### PR TITLE
Remove redundant requirement

### DIFF
--- a/template/tox.ini.jinja
+++ b/template/tox.ini.jinja
@@ -9,9 +9,7 @@ setenv =
 commands = pytest {posargs}
 
 [testenv:nightly]
-deps =
-  -r requirements/nightly.txt
-  pytest
+deps = -r requirements/nightly.txt
 commands = pytest
 
 [testenv:unpinned]


### PR DESCRIPTION
The separate pytest dep is not needed any more since #113