### PR TITLE
Disable "wanrings as errors" settings from pyproject.toml in conda build

### DIFF
--- a/template/conda/meta.yaml.jinja
+++ b/template/conda/meta.yaml.jinja
@@ -22,7 +22,8 @@ test:
     - pyproject.toml
     - tests/
   commands:
-    - python -m pytest tests
+    # We ignore warnings during release package builds
+    - python -m pytest -Wignore tests
 
 build:
   noarch: python


### PR DESCRIPTION
This can otherwise break releases. Recent example: h5py minor version warnings in scipp/chexus release.