### PR TITLE
Fix broken import test of namespace-package during conda build

### DIFF
--- a/template/conda/meta.yaml.jinja
+++ b/template/conda/meta.yaml.jinja
@@ -15,7 +15,7 @@ requirements:
 
 test:
   imports:
-    - {{projectname}}
+    - {% if namespace_package %}{{namespace_package}}.{% endif %}{{ projectname.removeprefix(namespace_package) }}
   requires:
     - pytest
   source_files:


### PR DESCRIPTION
This problem prevented, e.g., a release of `essdiffraction`.