### PR TITLE
Use CI pre-commit action.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3
         with:
           extra_args: --all-files
-      - uses: pre-commit-ci/lite-action@v1.0.1
+      - uses: pre-commit-ci/lite-action@v1
         if: always()
         with:
           msg: Apply automatic formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-      - uses: pre-commit/action@v3
+      - uses: pre-commit/action@v3.0.1
         with:
           extra_args: --all-files
-      - uses: pre-commit-ci/lite-action@v1
+      - uses: pre-commit-ci/lite-action@v1.0.1
         if: always()
         with:
           msg: Apply automatic formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,14 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-      - run: python -m pip install --upgrade pip
-      - run: python -m pip install -r requirements/ci.txt
-      - run: tox -e static
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - uses: pre-commit/action@v3.0.0
         with:
-          commit_message: Apply automatic formatting
+          extra_args: --all-files
+      - uses: pre-commit-ci/lite-action@v1.0.1
+        if: always()
+        with:
+          msg: Apply automatic formatting
+
   tests:
     name: Tests
     needs: formatting

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -27,12 +27,13 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version-file: '.github/workflows/python-version-ci'
-      - run: python -m pip install --upgrade pip
-      - run: python -m pip install -r requirements/ci.txt
-      - run: tox -e static
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - uses: pre-commit/action@v3.0.0
         with:
-          commit_message: Apply automatic formatting
+          extra_args: --all-files
+      - uses: pre-commit-ci/lite-action@v1.0.1
+        if: always()
+        with:
+          msg: Apply automatic formatting
 
   tests:
     name: Tests

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version-file: '.github/workflows/python-version-ci'
-      - uses: pre-commit/action@v3
+      - uses: pre-commit/action@v3.0.1
         with:
           extra_args: --all-files
-      - uses: pre-commit-ci/lite-action@v1
+      - uses: pre-commit-ci/lite-action@v1.0.1
         if: always()
         with:
           msg: Apply automatic formatting

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version-file: '.github/workflows/python-version-ci'
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3
         with:
           extra_args: --all-files
-      - uses: pre-commit-ci/lite-action@v1.0.1
+      - uses: pre-commit-ci/lite-action@v1
         if: always()
         with:
           msg: Apply automatic formatting


### PR DESCRIPTION
Fixes #104 
I updated the ``ci.yml`` of the ``copier_template`` workflow to use ``pre-commit`` action itself.
The ``template`` is not updated yet.

TODO: 
- [ ] Install pre-commit action in repositories (including ``copier_template``)
- [x] Add pre-commit action in ``template`` ci recipes

It was tested with ``essnmx``: https://github.com/scipp/essnmx/pull/12.