### PR TITLE
Install basetest requirements for unpinned test.

### DIFF
--- a/template/tox.ini.jinja
+++ b/template/tox.ini.jinja
@@ -15,6 +15,7 @@ commands = pytest
 [testenv:unpinned]
 description = Test with unpinned dependencies, as a user would install now.
 deps =
+  -r requirements/basetest.txt
   {{projectname}}
   pytest
 commands = pytest

--- a/template/tox.ini.jinja
+++ b/template/tox.ini.jinja
@@ -17,7 +17,6 @@ description = Test with unpinned dependencies, as a user would install now.
 deps =
   -r requirements/basetest.txt
   {{projectname}}
-  pytest
 commands = pytest
 
 [testenv:docs]


### PR DESCRIPTION
The package requirements doesn't have all required dependencies for tests.

For example, beamlime unpinned test failed since it was using extra packages for tests: https://github.com/scipp/beamlime/actions/runs/7374353847/job/20064645129

So... does it make sense to install ``basetest.txt`` for unpinned tests...?