### PR TITLE
Update `actions` action and dependabot configuration.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       # if you use those, you don't need updates.
       - dependency-name: "actions/*"
   - package-ecosystem: "github-actions"
-    directory: "/template"
+    directory: "/template/.github/workflows"  # Should specify full path if it's not '/'.
     schedule:
       interval: "weekly"
     ignore:

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: pre-commit/action@v3.0.1
         with:
           extra_args: --all-files
-      - uses: pre-commit-ci/lite-action@v1.0.1
+      - uses: pre-commit-ci/lite-action@v1.0.2
         if: always()
         with:
           msg: Apply automatic formatting

--- a/template/.github/workflows/docs.yml
+++ b/template/.github/workflows/docs.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: 'ubuntu-22.04'
     steps:
       - run: sudo apt install --yes graphviz pandoc
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch == '' && github.ref_name || inputs.branch }}
           fetch-depth: 0  # history required so cmake can determine version

--- a/template/.github/workflows/release.yml
+++ b/template/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: 'ubuntu-22.04'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0  # history required so setuptools_scm can determine version
@@ -41,7 +41,7 @@ jobs:
     runs-on: 'ubuntu-22.04'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # history required so setuptools_scm can determine version
 

--- a/template/.github/workflows/test.yml
+++ b/template/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ${{ inputs.os-variant }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.checkout_ref }}
       - uses: actions/setup-python@v3

--- a/template/.github/workflows/test.yml
+++ b/template/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.checkout_ref }}
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
       - run: python -m pip install --upgrade pip


### PR DESCRIPTION
These actions were ignored by the dependabot becuase of this option:
```yaml
ignore:
      # Optional: Official actions have moving tags like v1;
      # if you use those, you don't need updates.
      - dependency-name: "actions/*"
```

But it was weird that ``pre-commit`` was not updated either,
and it seems like if it is not '/', you should provide full-path to the workflows...?
It's not explicitly mentioned but it only mentions that it finds `.github/workflows` if the path is `/`. 
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directory

So I also updated them manually but later dependabot should be able to pick it up.