### PR TITLE
Rename Developer documentation section to Development

### DIFF
--- a/template/docs/developer/index.md.jinja
+++ b/template/docs/developer/index.md.jinja
@@ -1,4 +1,4 @@
-# Developer documentation
+# Development
 
 ```{include} ../../CONTRIBUTING.md
 ```


### PR DESCRIPTION
I feel that `Developer documentation` is too long and takes too much space in the navigation bar, so I renamed to `Development` (used by Numpy).