### PR TITLE
Update action versions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: 'ubuntu-22.04'
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - uses: pre-commit/action@v3.0.1
@@ -31,7 +31,7 @@ jobs:
       DUMMYPROJECTPATH: './test-dummy'
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - run: pip install copier

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           echo "min_python=$(cat .github/workflows/python-version-ci)" >> $GITHUB_OUTPUT
           echo "min_tox_env=py$(cat .github/workflows/python-version-ci | sed 's/\.//g')" >> $GITHUB_OUTPUT
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version-file: '.github/workflows/python-version-ci'
       - uses: pre-commit/action@v3.0.1

--- a/template/.github/workflows/docs.yml
+++ b/template/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           ref: ${{ inputs.branch == '' && github.ref_name || inputs.branch }}
           fetch-depth: 0  # history required so cmake can determine version
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version-file: '.github/workflows/python-version-ci'
       - run: python -m pip install --upgrade pip

--- a/template/.github/workflows/docs.yml
+++ b/template/.github/workflows/docs.yml
@@ -59,7 +59,7 @@ jobs:
         if: ${{ inputs.version == '' }}
       - run: tox -e linkcheck
         if: ${{ inputs.linkcheck }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: docs_html
           path: html/

--- a/template/.github/workflows/test.yml
+++ b/template/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -r ${{ inputs.pip-recipe }}
       - run: tox -e ${{ inputs.tox-env }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ inputs.coverage-report }}
         with:
           name: CoverageReport

--- a/template/.github/workflows/{% if orgname == "scipp" %}release.yml{% endif %}
+++ b/template/.github/workflows/{% if orgname == "scipp" %}release.yml{% endif %}
@@ -42,7 +42,7 @@ jobs:
         with:
           fetch-depth: 0  # history required so setuptools_scm can determine version
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version-file: '.github/workflows/python-version-ci'
 

--- a/template/.github/workflows/{% if orgname == "scipp" %}release.yml{% endif %}
+++ b/template/.github/workflows/{% if orgname == "scipp" %}release.yml{% endif %}
@@ -28,7 +28,7 @@ jobs:
             boa
       - run: conda mambabuild --channel conda-forge --channel scipp --no-anaconda-upload --override-channels --output-folder conda/package conda
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: conda-package-noarch
           path: conda/package/noarch/*.tar.bz2
@@ -53,7 +53,7 @@ jobs:
         run: python -m build
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist


### PR DESCRIPTION
Due to deprecated node js version, we need to update actions.
The major-only version actions are excluded from the dependa bot, so we have to manually update them.

`upload-artifact` action was tested in ``scipp`` repo. From version 4, all artifacts should have different name within the same job, but it looks like except for `scipp` other packages don't make multiple artifacts with the same name so it should be fine.

These are the warning messages in the PR/main merge github actions:

> [Formatting and static analysis](https://github.com/scipp/essdiffraction/actions/runs/8293312488/job/22696163521)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

> [docs / Build documentation](https://github.com/scipp/essdiffraction/actions/runs/8293312488/job/22696261947)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-python@v4, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.