### PR TITLE
Generate conda/meta.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: check-merge-conflict
       - id: check-toml
       - id: check-yaml
-        exclude: conda/meta.yaml
+        exclude: 'conda/meta(_template)?.yaml'
       - id: detect-private-key
       - id: trailing-whitespace
         args: [ --markdown-linebreak-ext=md ]

--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: check-merge-conflict
       - id: check-toml
       - id: check-yaml
-        exclude: conda/meta.yaml
+        exclude: 'conda/meta(_template)?.yaml'
       - id: detect-private-key
       - id: trailing-whitespace
         args: [ --markdown-linebreak-ext=md ]

--- a/template/conda/make_conda_meta.py
+++ b/template/conda/make_conda_meta.py
@@ -83,7 +83,7 @@ def main() -> None:
     meta['about'] = {
         'home': project['urls']['Source'],
         'dev_url': project['urls']['Source'],
-        'docs_url': project['urls']['Documentation'],
+        'doc_url': project['urls']['Documentation'],
         'summary': project['description'],
         'description': project['description'],
         'license': identify_license(),

--- a/template/conda/make_conda_meta.py
+++ b/template/conda/make_conda_meta.py
@@ -1,0 +1,103 @@
+"""Generate a meta.yaml file for conda.
+
+The file is based on `conda/meta_template.yaml` and `pyproject.toml`.
+"""
+from pathlib import Path
+from typing import Any
+
+import tomli
+import yaml
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+
+
+def read_pyproject() -> dict[str, Any]:
+    with ROOT_DIR.joinpath('pyproject.toml').open('rb') as f:
+        return tomli.load(f)
+
+
+def read_conda_meta_template() -> dict[str, Any]:
+    with ROOT_DIR.joinpath('conda', 'meta_template.yaml').open('rb') as f:
+        return yaml.safe_load(f)
+
+
+def read_test_requirements() -> list[str]:
+    basetest = ROOT_DIR.joinpath('requirements', 'basetest.in').read_text()
+    requirements = []
+    for line in basetest.splitlines():
+        line = line.strip()
+        if line.startswith('-r') or line.startswith('-i'):
+            raise NotImplementedError('Requirements files that include other files are not supported.')
+        if line.startswith('#') or not line:
+            continue
+        requirements.append(line)
+    return requirements
+
+
+def write_conda_meta(meta: dict[str, Any]) -> None:
+    # The order of keys in meta.yaml matters for some bizarre reason,
+    # so specify sort_keys=False and rely on the order in the template.
+    with ROOT_DIR.joinpath('conda', 'meta.yaml').open('w') as f:
+        yaml.dump(meta, f, sort_keys=False)
+
+
+def identify_license() -> str:
+    text = ROOT_DIR.joinpath('LICENSE').read_text()
+    if text.startswith('BSD 3-Clause License'):
+        return 'BSD-3-Clause'
+    raise ValueError(f'Could not identify license. Please update {__file__}')
+
+
+def split_dependency_version(dependency: str) -> tuple[str, str]:
+    # Return two strings that can be concatenated to form a valid
+    # requirement string.
+    for relation in ('==', '>', '>=', '<', '<=', '!='):
+        dep, *version = dependency.split(relation, 1)
+        if version:
+            return dep, relation + version[0]
+    return dependency, ''
+
+
+def map_to_conda_requirements(dependencies: list[str], dependency_map: dict[str, str]) -> list[str]:
+    mapped = []
+    for dep in dependencies:
+        dep, version = split_dependency_version(dep)
+        mapped.append(dependency_map.get(dep, dep) + version)
+    return mapped
+
+
+def check_dependencies(dependencies: list[str]) -> list[str]:
+    for dep in dependencies:
+        if '[' in dep:
+            raise ValueError(f"Conda dependencies must not contain brackets, found '{dep}'")
+    return dependencies
+
+
+def main() -> None:
+    pyproject = read_pyproject()
+    project = pyproject['project']
+    dependency_map = pyproject['tool']['conda_meta']['dependency_map']
+
+    meta = read_conda_meta_template()
+    meta['package']['name'] = project['name']
+    meta['about'] = {
+        'home': project['urls']['Source'],
+        'dev_url': project['urls']['Source'],
+        'docs_url': project['urls']['Documentation'],
+        'summary': project['description'],
+        'description': project['description'],
+        'license': identify_license(),
+    }
+    meta['requirements']['run'] = check_dependencies([
+        *map_to_conda_requirements(project['dependencies'], dependency_map),
+        *pyproject['tool']['conda_meta']['extra_dependencies']['run'],
+        f'python{project["requires-python"]}'])
+    meta['test']['requires'] = check_dependencies([
+        *map_to_conda_requirements(read_test_requirements(), dependency_map),
+        *pyproject['tool']['conda_meta']['extra_dependencies']['test']])
+
+    write_conda_meta(meta)
+
+
+if __name__ == '__main__':
+    main()

--- a/template/conda/meta_template.yaml
+++ b/template/conda/meta_template.yaml
@@ -1,8 +1,8 @@
 package:
-  name: {{projectname}}
 {% raw %}
   version: {{ GIT_DESCRIBE_TAG }}
 {% endraw %}
+
 source:
   path: ..
 
@@ -10,14 +10,10 @@ requirements:
   build:
     - setuptools
     - setuptools_scm
-  run:
-    - python>={{min_python}}
 
 test:
   imports:
     - {% if namespace_package %}{{namespace_package}}.{% endif %}{{ projectname.removeprefix(namespace_package) }}
-  requires:
-    - pytest
   source_files:
     - pyproject.toml
     - tests/
@@ -29,11 +25,3 @@ build:
   noarch: python
   script:
     - python -m pip install .
-
-about:
-  home: https://github.com/{{orgname}}/{{projectname}}
-  license: BSD-3-Clause
-  summary: {{description}}
-  description: {{description}}
-  dev_url: https://github.com/{{orgname}}/{{projectname}}
-  doc_url: https://{{orgname}}.github.io/{{projectname}}

--- a/template/conda/meta_template.yaml.jinja
+++ b/template/conda/meta_template.yaml.jinja
@@ -1,6 +1,6 @@
 package:
 {% raw %}
-  version: {{ GIT_DESCRIBE_TAG }}
+  version: "{{ GIT_DESCRIBE_TAG }}"
 {% endraw %}
 
 source:

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -26,13 +26,32 @@ classifiers = [
 ]
 requires-python = ">={{min_python}}"
 
+dynamic = ["version"]
+
 # IMPORTANT:
 # Run 'tox -e deps' after making changes here. This will update requirement files.
 # Make sure to list one dependency per line.
 dependencies = [
 ]
 
-dynamic = ["version"]
+# Map from pip package names to conda package names
+# when the two are different.
+# Used for both package dependencies and test dependencies.
+# Must include optional dependency spec and all extra requirements
+# must be listed under `tool.conda_meta.extra_dependencies.run`
+# or `tool.conda_meta.extra_dependencies.test`
+# E.g.
+#  graphviz = "python-graphviz"
+#  "scipp[all]" = "scipp"
+[tool.conda_meta.dependency_map]
+
+# List any dependencies needed by the conda package
+# but not by the wheel or regular project tests.
+[tool.conda_meta.extra_dependencies]
+run = [
+]
+test = [
+]
 
 [project.urls]
 "Bug Tracker" = "https://github.com/{{orgname}}/{{projectname}}/issues"

--- a/template/tox.ini.jinja
+++ b/template/tox.ini.jinja
@@ -65,3 +65,4 @@ skip_install = true
 changedir = requirements
 commands = python ./make_base.py{% if nightly_deps %} --nightly {{nightly_deps}}{% endif %}
            pip-compile-multi -d . --backtracking
+           python ../conda/make_conda_meta.py

--- a/template/tox.ini.jinja
+++ b/template/tox.ini.jinja
@@ -60,6 +60,7 @@ commands = python -m mypy .
 description = Update dependencies by running pip-compile-multi
 deps =
   pip-compile-multi
+  pyyaml
   tomli
 skip_install = true
 changedir = requirements


### PR DESCRIPTION
Fixes #85

Please have a careful look to see whether this works for all projects. I think it does but I may have missed a case.

As an example, in Sciline, all that is needed is to change the new content in `pyproject.toml` to
```toml
[tool.conda_meta.dependency_map]
graphviz = "python-graphviz"

[tool.conda_meta.extra_dependencies]
run = [
]
test = [
]
```
because `graphviz` is used in `basetest.in`.

The `extra_dependencies` mapping exists for cases where we depend on, e.g., `scipp[interactive]` in pip and depending on `scipp` in conda is not enough. Then we can add missing stuff here.
I thought we had a case like this. However, after implementing it, I could not find one. The only thing I did find is `scipp[all]` in `base.in` in ScippNeutron. But that does not affect `conda/meta.yaml`.
So I can remove this feature if you prefer simplicity now and risk revisiting this in the future.