### PR TITLE
Remove obsolete static tox env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
         working-directory: ${{ env.DUMMYPROJECTPATH }}
       - run: tox -e py39
         working-directory: ${{ env.DUMMYPROJECTPATH }}
+      # We normally run pre-commit via the pre-commit action.
+      # But that doesn't work here because we want to run it in a different directory.
       - run: tox -e static
         working-directory: ${{ env.DUMMYPROJECTPATH }}
       - run: tox -e docs

--- a/template/requirements/dev.in
+++ b/template/requirements/dev.in
@@ -2,7 +2,6 @@
 -r ci.in
 -r docs.in
 -r mypy.in
--r static.in
 -r test.in
 -r wheels.in
 copier

--- a/template/requirements/static.in
+++ b/template/requirements/static.in
@@ -1,1 +1,0 @@
-pre-commit

--- a/template/tox.ini.jinja
+++ b/template/tox.ini.jinja
@@ -41,16 +41,6 @@ description = Run Sphinx linkcheck
 deps = -r requirements/docs.txt
 commands = python -m sphinx -j2 -v -b linkcheck -d {toxworkdir}/docs_doctrees docs html
 
-[testenv:static]
-description = Code formatting and static analysis
-skip_install = true
-deps = -r requirements/static.txt
-allowlist_externals = sh
-# The first run of pre-commit may reformat files. If this happens, it returns 1 but this
-# should not fail the job. So just run again if it fails. A second failure means that
-# either the different formatters can't agree on a format or that static analysis failed.
-commands = sh -c 'pre-commit run -a || (echo "" && pre-commit run -a)'
-
 [testenv:mypy]
 description = Type checking (mypy)
 deps = -r requirements/mypy.txt

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,11 @@
 description = Code formatting and static analysis
 skip_install = true
 deps = -r requirements/static.txt
-allowlist_externals = sh
-# The first run of pre-commit may reformat files. If this happens, it returns 1 but this
-# should not fail the job. So just run again if it fails. A second failure means that
-# either the different formatters can't agree on a format or that static analysis failed.
-commands = sh -c 'pre-commit run -a || (echo "" && pre-commit run -a)'
+allowlist_externals = pre-commit
+# This fails if anything is reformatted.
+# So this should only be used when testing a rendered project,
+# not for static analysis/formatting of the template itself.
+commands = pre-commit run -a
 
 [testenv:deps]
 description = Update dependencies by running pip-compile-multi


### PR DESCRIPTION
We run static analysis via the pre-commit action now. So we no longer need the `static` tox env.