### PR TITLE
Infer version number in docs through importlib machinery

### DIFF
--- a/template/docs/conf.py.jinja
+++ b/template/docs/conf.py.jinja
@@ -3,6 +3,7 @@
 import doctest
 import os
 import sys
+from importlib.metadata import version as get_version
 
 {% if namespace_package %}from {{namespace_package}} {% endif %}import {{ projectname.removeprefix(namespace_package) }}
 
@@ -111,10 +112,8 @@ master_doc = 'index'
 # built documents.
 #
 
-# The short X.Y version.
-version = {{ projectname.removeprefix(namespace_package) }}.__version__
-# The full version, including alpha/beta/rc tags.
-release = {{ projectname.removeprefix(namespace_package) }}.__version__
+release = get_version("{{projectname}}")
+version = ".".join(release.split('.')[:3])  # CalVer
 
 warning_is_error = True
 


### PR DESCRIPTION
Due to inconsistent usage of setuptools_scm it may pick up the wrong version numbers when building docs. This should force sphinx to use the correct version numbers.