### PR TITLE
Remove pyyaml-include pin, fixed upstream

### DIFF
--- a/template/requirements/dev.in
+++ b/template/requirements/dev.in
@@ -9,6 +9,3 @@ copier
 jupyterlab
 pip-compile-multi
 pre-commit
-
-# See https://github.com/copier-org/copier/issues/1568
-pyyaml-include<2


### PR DESCRIPTION
With this we can test out the downstream action too https://github.com/scipp/esssans/actions/workflows/copier.yml