### PR TITLE
Disable domain-type-related ruff rules in notebooks

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -83,6 +83,8 @@ pydocstyle.convention = "numpy"
 ]
 "*.ipynb" = [
     "E501",  # longer lines are sometimes more readable
+    "F403",  # *-imports used with domain types
+    "F405",  # linter may fail to find names because of *-imports
     "I",  # we don't collect imports at the top
     "S101",  # asserts are used for demonstration and are safe in notebooks
     "T201",  # printing is ok for demonstration purposes


### PR DESCRIPTION
And another PR about ruff. It is not great to disable these rules but this is a consequence of how we use `types` modules. Ultimately, they do not detect any problems that we wouldn't catch at runtime when building the docs.