### PR TITLE
Update ruff to 0.4.3

### DIFF
--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         args: [ "--drop-empty-cells",
                 "--extra-keys 'metadata.language_info.version cell.metadata.jp-MarkdownHeadingCollapsed cell.metadata.pycharm'" ]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.1
+    rev: v0.4.3
     hooks:
       - id: ruff
         args: [ --fix ]


### PR DESCRIPTION
This adds support for the generic function syntax of Python 3.12. Not that we use it in production at the moment but it helps to get that hurdle out of the way.