### PR TITLE
Remove unnecessary encoding annotation.

### DIFF
--- a/template/docs/conf.py.jinja
+++ b/template/docs/conf.py.jinja
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import doctest
 import os
 import sys


### PR DESCRIPTION
Apparently it's not needed according to the UP rules:
``UP009 UTF-8 encoding declaration is unnecessary``