### PR TITLE
Catch importlib error when building docs with sphinx-build manually

### DIFF
--- a/template/docs/conf.py.jinja
+++ b/template/docs/conf.py.jinja
@@ -4,7 +4,11 @@ import sys
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as get_version
 
+from sphinx.util import logging
+
 sys.path.insert(0, os.path.abspath('.'))
+
+logger = logging.getLogger(__name__)
 
 # General information about the project.
 project = '{{prettyname}}'
@@ -114,6 +118,10 @@ try:
     release = get_version("{{projectname}}")
     version = ".".join(release.split('.')[:3])  # CalVer
 except PackageNotFoundError:
+    logger.info(
+        "Warning: determining version from package metadata failed, falling back to "
+        "a dummy version number."
+    )
     release = version = "0.0.0-dev"
 
 warning_is_error = True

--- a/template/docs/conf.py.jinja
+++ b/template/docs/conf.py.jinja
@@ -1,6 +1,7 @@
 import doctest
 import os
 import sys
+from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as get_version
 
 sys.path.insert(0, os.path.abspath('.'))
@@ -109,8 +110,11 @@ master_doc = 'index'
 # built documents.
 #
 
-release = get_version("{{projectname}}")
-version = ".".join(release.split('.')[:3])  # CalVer
+try:
+    release = get_version("{{projectname}}")
+    version = ".".join(release.split('.')[:3])  # CalVer
+except PackageNotFoundError:
+    release = version = "0.0.0-dev"
 
 warning_is_error = True
 


### PR DESCRIPTION
In some cases, where a local source for a package (e.g. in the PYTHONPATH) is used instead of a `pip` install package, the `get_version()` in the `docs/conf.py` fails with `importlib.metadata.PackageNotFoundError: No package metadata was found for PACKAGE` when using `sphinx-build` directly (instead of going via `tox -e docs`).

These changes allows one to use `sphinx-build` directly, which is sometimes needed for debugging purposes.