### PR TITLE
Suppress Sphinx cache warning

### DIFF
--- a/template/docs/conf.py.jinja
+++ b/template/docs/conf.py.jinja
@@ -37,6 +37,8 @@ try:
     import sciline.sphinxext.domain_types  # noqa: F401
 
     extensions.append('sciline.sphinxext.domain_types')
+    # See https://github.com/tox-dev/sphinx-autodoc-typehints/issues/457
+    suppress_warnings = ["config.cache"]
 except ModuleNotFoundError:
     pass
 {% endif %}


### PR DESCRIPTION
Workaround until https://github.com/tox-dev/sphinx-autodoc-typehints/issues/457 is fixed. The warning is caused by setting `typehints_formatter` in `sciline.sphinxext.domain_types`.

This was first found in https://github.com/scipp/scippneutron/pull/519 which seems to be the first time we treat warnings as errors and use the latest sphinx.