### PR TITLE
ci: expose protected file credentials in trusted workflows

### DIFF
--- a/template/.github/workflows/nightly_at_main.yml
+++ b/template/.github/workflows/nightly_at_main.yml
@@ -21,6 +21,7 @@ jobs:
     name: Tests
     needs: setup
     env:
+        # Security note! The secrets are only added to workflows that run on trusted branches (main). If secrets are accessible in workflows that run on untrusted branches they can be extracted, see https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#exfiltrating-data-from-a-runner.
         ESS_PROTECTED_FILESTORE_USERNAME: ${{ secrets.ESS_PROTECTED_FILESTORE_USERNAME }}
         ESS_PROTECTED_FILESTORE_PASSWORD: ${{ secrets.ESS_PROTECTED_FILESTORE_PASSWORD }}
     strategy:

--- a/template/.github/workflows/nightly_at_main.yml
+++ b/template/.github/workflows/nightly_at_main.yml
@@ -20,6 +20,9 @@ jobs:
   tests:
     name: Tests
     needs: setup
+    env:
+        ESS_PROTECTED_FILESTORE_USERNAME: ${{ secrets.ESS_PROTECTED_FILESTORE_USERNAME }}
+        ESS_PROTECTED_FILESTORE_PASSWORD: ${{ secrets.ESS_PROTECTED_FILESTORE_PASSWORD }}
     strategy:
       matrix:
         os: ['ubuntu-22.04']

--- a/template/.github/workflows/nightly_at_release.yml
+++ b/template/.github/workflows/nightly_at_release.yml
@@ -26,6 +26,9 @@ jobs:
   tests:
     name: Tests
     needs: setup
+    env:
+        ESS_PROTECTED_FILESTORE_USERNAME: ${{ secrets.ESS_PROTECTED_FILESTORE_USERNAME }}
+        ESS_PROTECTED_FILESTORE_PASSWORD: ${{ secrets.ESS_PROTECTED_FILESTORE_PASSWORD }}
     strategy:
       matrix:
         os: ['ubuntu-22.04']

--- a/template/.github/workflows/nightly_at_release.yml
+++ b/template/.github/workflows/nightly_at_release.yml
@@ -27,6 +27,7 @@ jobs:
     name: Tests
     needs: setup
     env:
+        # Security note! The secrets are only added to workflows that run on trusted branches (main). If secrets are accessible in workflows that run on untrusted branches they can be extracted, see https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#exfiltrating-data-from-a-runner.
         ESS_PROTECTED_FILESTORE_USERNAME: ${{ secrets.ESS_PROTECTED_FILESTORE_USERNAME }}
         ESS_PROTECTED_FILESTORE_PASSWORD: ${{ secrets.ESS_PROTECTED_FILESTORE_PASSWORD }}
     strategy:

--- a/template/.github/workflows/unpinned.yml
+++ b/template/.github/workflows/unpinned.yml
@@ -26,6 +26,9 @@ jobs:
   tests:
     name: Tests
     needs: setup
+    env:
+        ESS_PROTECTED_FILESTORE_USERNAME: ${{ secrets.ESS_PROTECTED_FILESTORE_USERNAME }}
+        ESS_PROTECTED_FILESTORE_PASSWORD: ${{ secrets.ESS_PROTECTED_FILESTORE_PASSWORD }}
     strategy:
       matrix:
         os: ['ubuntu-22.04']

--- a/template/.github/workflows/unpinned.yml
+++ b/template/.github/workflows/unpinned.yml
@@ -27,6 +27,7 @@ jobs:
     name: Tests
     needs: setup
     env:
+        # Security note! The secrets are only added to workflows that run on trusted branches (main). If secrets are accessible in workflows that run on untrusted branches they can be extracted, see https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#exfiltrating-data-from-a-runner.
         ESS_PROTECTED_FILESTORE_USERNAME: ${{ secrets.ESS_PROTECTED_FILESTORE_USERNAME }}
         ESS_PROTECTED_FILESTORE_PASSWORD: ${{ secrets.ESS_PROTECTED_FILESTORE_PASSWORD }}
     strategy:

--- a/template/.github/workflows/{% if orgname == 'scipp' %}release.yml{% endif %}
+++ b/template/.github/workflows/{% if orgname == 'scipp' %}release.yml{% endif %}
@@ -8,6 +8,10 @@ on:
 defaults:
   run:
     shell: bash -l {0}  # required for conda env
+  env:
+    ESS_PROTECTED_FILESTORE_USERNAME: ${{ secrets.ESS_PROTECTED_FILESTORE_USERNAME }}
+    ESS_PROTECTED_FILESTORE_PASSWORD: ${{ secrets.ESS_PROTECTED_FILESTORE_PASSWORD }}
+
 
 jobs:
   build_conda:

--- a/template/.github/workflows/{% if orgname == 'scipp' %}release.yml{% endif %}
+++ b/template/.github/workflows/{% if orgname == 'scipp' %}release.yml{% endif %}
@@ -9,6 +9,7 @@ defaults:
   run:
     shell: bash -l {0}  # required for conda env
   env:
+    # Security note! The secrets are only added to workflows that run on trusted branches (main). If secrets are accessible in workflows that run on untrusted branches they can be extracted, see https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#exfiltrating-data-from-a-runner.
     ESS_PROTECTED_FILESTORE_USERNAME: ${{ secrets.ESS_PROTECTED_FILESTORE_USERNAME }}
     ESS_PROTECTED_FILESTORE_PASSWORD: ${{ secrets.ESS_PROTECTED_FILESTORE_PASSWORD }}
 


### PR DESCRIPTION
This change adds environment variables containing credentials that can be used to read files in the [protected folder](https://public.esss.dk/groups/scipp/protected/) on the file server.

The environment variables are only added to workflows that run on the main branch that is assumed to be trusted.
If the environment variables would be added to typical CI workflows then the credentials could be extracted by someone without write permission to the main branch.

With this change workflows can look for the environment variables and read protected files if they find them.