### PR TITLE
fix: set credentials in all test/docs workflows

### DIFF
--- a/template/.github/workflows/docs.yml
+++ b/template/.github/workflows/docs.yml
@@ -42,6 +42,11 @@ jobs:
   docs:
     name: Build documentation
     runs-on: 'ubuntu-22.04'
+    env:
+        # Security note! The secrets are only added to workflows that run on trusted branches (main). If secrets are accessible in workflows that run on untrusted branches they can be extracted, see https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#exfiltrating-data-from-a-runner.
+        ESS_PROTECTED_FILESTORE_USERNAME: ${{ secrets.ESS_PROTECTED_FILESTORE_USERNAME }}
+        ESS_PROTECTED_FILESTORE_PASSWORD: ${{ secrets.ESS_PROTECTED_FILESTORE_PASSWORD }}
+
     steps:
       - run: sudo apt install --yes graphviz pandoc
       - uses: actions/checkout@v4

--- a/template/.github/workflows/docs.yml
+++ b/template/.github/workflows/docs.yml
@@ -43,7 +43,6 @@ jobs:
     name: Build documentation
     runs-on: 'ubuntu-22.04'
     env:
-        # Security note! The secrets are only added to workflows that run on trusted branches (main). If secrets are accessible in workflows that run on untrusted branches they can be extracted, see https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#exfiltrating-data-from-a-runner.
         ESS_PROTECTED_FILESTORE_USERNAME: ${{ secrets.ESS_PROTECTED_FILESTORE_USERNAME }}
         ESS_PROTECTED_FILESTORE_PASSWORD: ${{ secrets.ESS_PROTECTED_FILESTORE_PASSWORD }}
 

--- a/template/.github/workflows/nightly_at_main.yml
+++ b/template/.github/workflows/nightly_at_main.yml
@@ -20,10 +20,6 @@ jobs:
   tests:
     name: Tests
     needs: setup
-    env:
-        # Security note! The secrets are only added to workflows that run on trusted branches (main). If secrets are accessible in workflows that run on untrusted branches they can be extracted, see https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#exfiltrating-data-from-a-runner.
-        ESS_PROTECTED_FILESTORE_USERNAME: ${{ secrets.ESS_PROTECTED_FILESTORE_USERNAME }}
-        ESS_PROTECTED_FILESTORE_PASSWORD: ${{ secrets.ESS_PROTECTED_FILESTORE_PASSWORD }}
     strategy:
       matrix:
         os: ['ubuntu-22.04']

--- a/template/.github/workflows/nightly_at_release.yml
+++ b/template/.github/workflows/nightly_at_release.yml
@@ -26,10 +26,6 @@ jobs:
   tests:
     name: Tests
     needs: setup
-    env:
-        # Security note! The secrets are only added to workflows that run on trusted branches (main). If secrets are accessible in workflows that run on untrusted branches they can be extracted, see https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#exfiltrating-data-from-a-runner.
-        ESS_PROTECTED_FILESTORE_USERNAME: ${{ secrets.ESS_PROTECTED_FILESTORE_USERNAME }}
-        ESS_PROTECTED_FILESTORE_PASSWORD: ${{ secrets.ESS_PROTECTED_FILESTORE_PASSWORD }}
     strategy:
       matrix:
         os: ['ubuntu-22.04']

--- a/template/.github/workflows/test.yml
+++ b/template/.github/workflows/test.yml
@@ -44,7 +44,6 @@ jobs:
   test:
     runs-on: ${{ inputs.os-variant }}
     env:
-        # Security note! The secrets are only added to workflows that run on trusted branches (main). If secrets are accessible in workflows that run on untrusted branches they can be extracted, see https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#exfiltrating-data-from-a-runner.
         ESS_PROTECTED_FILESTORE_USERNAME: ${{ secrets.ESS_PROTECTED_FILESTORE_USERNAME }}
         ESS_PROTECTED_FILESTORE_PASSWORD: ${{ secrets.ESS_PROTECTED_FILESTORE_PASSWORD }}
 

--- a/template/.github/workflows/test.yml
+++ b/template/.github/workflows/test.yml
@@ -43,6 +43,10 @@ on:
 jobs:
   test:
     runs-on: ${{ inputs.os-variant }}
+    env:
+        # Security note! The secrets are only added to workflows that run on trusted branches (main). If secrets are accessible in workflows that run on untrusted branches they can be extracted, see https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#exfiltrating-data-from-a-runner.
+        ESS_PROTECTED_FILESTORE_USERNAME: ${{ secrets.ESS_PROTECTED_FILESTORE_USERNAME }}
+        ESS_PROTECTED_FILESTORE_PASSWORD: ${{ secrets.ESS_PROTECTED_FILESTORE_PASSWORD }}
 
     steps:
       - uses: actions/checkout@v4

--- a/template/.github/workflows/unpinned.yml
+++ b/template/.github/workflows/unpinned.yml
@@ -26,10 +26,6 @@ jobs:
   tests:
     name: Tests
     needs: setup
-    env:
-        # Security note! The secrets are only added to workflows that run on trusted branches (main). If secrets are accessible in workflows that run on untrusted branches they can be extracted, see https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#exfiltrating-data-from-a-runner.
-        ESS_PROTECTED_FILESTORE_USERNAME: ${{ secrets.ESS_PROTECTED_FILESTORE_USERNAME }}
-        ESS_PROTECTED_FILESTORE_PASSWORD: ${{ secrets.ESS_PROTECTED_FILESTORE_PASSWORD }}
     strategy:
       matrix:
         os: ['ubuntu-22.04']

--- a/template/.github/workflows/{% if orgname == 'scipp' %}release.yml{% endif %}
+++ b/template/.github/workflows/{% if orgname == 'scipp' %}release.yml{% endif %}
@@ -8,11 +8,6 @@ on:
 defaults:
   run:
     shell: bash -l {0}  # required for conda env
-  env:
-    # Security note! The secrets are only added to workflows that run on trusted branches (main). If secrets are accessible in workflows that run on untrusted branches they can be extracted, see https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#exfiltrating-data-from-a-runner.
-    ESS_PROTECTED_FILESTORE_USERNAME: ${{ secrets.ESS_PROTECTED_FILESTORE_USERNAME }}
-    ESS_PROTECTED_FILESTORE_PASSWORD: ${{ secrets.ESS_PROTECTED_FILESTORE_PASSWORD }}
-
 
 jobs:
   build_conda:


### PR DESCRIPTION
Related to https://github.com/scipp/scippneutron/issues/476

This change was already merged. But then we learnt some new things about when github secrets are available in workflows. They are not available in fork PRs.

This lets us simplify things by exposing the credentials in all `test` and `docs` actions. This removes the limitation that existed before, where only some actions could have access to secrets. Now all `tests` and `docs` actions will have access to protected files, unless they run in a fork PR.

More information in this MR to the DMSC docs: https://git.esss.dk/docs/dmsc/-/merge_requests/31/.

I also [got some feedback](https://github.com/scipp/copier_template/pull/192#discussion_r1671533053) that maybe this stuff should not go here in the generic copier template at all, but rather in the ESS specific copier template. That should also be addressed but I think it's better to do it in a separate PR.