### PR TITLE
Add ruff cache path to be ignored.

### DIFF
--- a/template/.gitignore.jinja
+++ b/template/.gitignore.jinja
@@ -20,6 +20,7 @@ __pycache__/
 .pytest_cache
 .mypy_cache
 docs/generated/
+.ruff_cache
 
 # Editor settings
 .idea/


### PR DESCRIPTION
We enabled ruff to all the repositories so we should add ruff cache folder in the gitignore list.