### PR TITLE
fix: let test and docs workflows inherit secrets

### DIFF
--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
       os-variant: ${{ matrix.os }}
       python-version: ${{ matrix.python.version }}
       tox-env: ${{ matrix.python.tox-env }}
+    secrets: inherit
 
   docs:
     needs: tests
@@ -54,3 +55,4 @@ jobs:
       publish: false
       linkcheck: ${{ contains(matrix.variant.os, 'ubuntu') && github.ref == 'refs/heads/main' }}
       branch: ${{ github.head_ref == '' && github.ref_name || github.head_ref }}
+    secrets: inherit

--- a/template/.github/workflows/nightly_at_main.yml
+++ b/template/.github/workflows/nightly_at_main.yml
@@ -31,3 +31,4 @@ jobs:
       os-variant: ${{ matrix.os }}
       python-version: ${{ matrix.python.version }}
       tox-env: ${{ matrix.python.tox-env }}
+    secrets: inherit

--- a/template/.github/workflows/nightly_at_release.yml
+++ b/template/.github/workflows/nightly_at_release.yml
@@ -38,3 +38,4 @@ jobs:
       python-version: ${{ matrix.python.version }}
       tox-env: ${{ matrix.python.tox-env }}
       checkout_ref: ${{ needs.setup.outputs.release_tag }}
+    secrets: inherit

--- a/template/.github/workflows/unpinned.yml
+++ b/template/.github/workflows/unpinned.yml
@@ -38,3 +38,4 @@ jobs:
       python-version: ${{ matrix.python.version }}
       tox-env: ${{ matrix.python.tox-env }}
       checkout_ref: ${{ needs.setup.outputs.release_tag }}
+    secrets: inherit


### PR DESCRIPTION
Secrets are not automatically propagated to called workflows.
The test and docs workflows might need secrets (to download protected files).
For called workflows that live in the same repo there is no security issue propagating the secrets.