### PR TITLE
fix: add prefix to scipp nightly dep

### DIFF
--- a/template/requirements/make_base.py
+++ b/template/requirements/make_base.py
@@ -55,7 +55,8 @@ def as_nightly(repo: str) -> str:
         version = f"cp{sys.version_info.major}{sys.version_info.minor}"
         base = "https://github.com/scipp/scipp/releases/download/nightly/scipp-nightly"
         suffix = "manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-        return "-".join([base, version, version, suffix])
+        prefix = "scipp @ "
+        return prefix + "-".join([base, version, version, suffix])
     return f"{repo} @ git+https://github.com/{org}/{repo}@main"
 
 


### PR DESCRIPTION
For some reason this fixes an error happening when running `tox -e deps` in esssans and essnmx.

The error message that motivated this change was:
```
pip._internal.exceptions.InstallationError: Invalid requirement: 'scipp==nightly': Expected end or semicolon (after name and no valid version specifier)
    scipp==nightly
         ^ (from line 14 of nightly.in)
```