### PR TITLE
Run package tests with minimal installation

### DIFF
--- a/template/.github/workflows/test.yml
+++ b/template/.github/workflows/test.yml
@@ -41,6 +41,21 @@ on:
         type: string
 
 jobs:
+  package-test:
+    runs-on: ${{ inputs.os-variant }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkout_ref }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install .
+      - run: python tests/package_test.py
+        name: Run package tests
+
   test:
     runs-on: ${{ inputs.os-variant }}
     env:

--- a/template/tests/package_test.py.jinja
+++ b/template/tests/package_test.py.jinja
@@ -1,7 +1,20 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) {{year}} {{orgname|capitalize}} contributors (https://github.com/{{orgname}})
+
+"""Tests of package integrity.
+
+Note that addidional imports need to be added for repositories that
+contain multiple packages.
+"""
+
 {% if namespace_package %}from {{namespace_package}} {% endif %}import {{ projectname.removeprefix(namespace_package) }} as pkg
 
 
 def test_has_version():
     assert hasattr(pkg, '__version__')
+
+
+# This is for CI package tests. They need to run tests with minimal dependencies,
+# that is, without installing pytest. This code does not affect pytest.
+if __name__ == '__main__':
+    test_has_version()


### PR DESCRIPTION
This is a generalised version of the test introduced in https://github.com/scipp/scippneutron/pull/534

The test is meant to check that the package can be imported when only required dependencies are installed.