### PR TITLE
deps: many packages need pooch to test

### DIFF
--- a/template/conda/meta.yaml.jinja
+++ b/template/conda/meta.yaml.jinja
@@ -29,6 +29,7 @@ test:
     - {% if namespace_package %}{{namespace_package}}.{% endif %}{{ projectname.removeprefix(namespace_package) }}
   requires:
     - pytest
+    - pooch
   source_files:
     - pyproject.toml
     - tests/


### PR DESCRIPTION
See for example https://github.com/scipp/esssans/actions/runs/10509106139/job/29114507114

Can we do something to make sure this is always in sync with `basetest.in`?