### PR TITLE
Git ignore *.zip

### DIFF
--- a/template/.gitignore.jinja
+++ b/template/.gitignore.jinja
@@ -39,3 +39,4 @@ docs/generated/
 *.cif
 *.rcif
 *.ort
+*.zip


### PR DESCRIPTION
GEANT4 simulation results are often stored as zip files. So they may end up in a repo but should not be committed.