### PR TITLE
Update CI action and fix ruff errors in docs/conf.py template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - uses: pre-commit/action@v3.0.1
         with:
           extra_args: --all-files
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - run: pip install -r requirements/ci.txt
       - run: |
             copier copy ./ ${DUMMYPROJECTPATH} \
@@ -41,18 +41,18 @@ jobs:
               -d description="Dummy project to test the template." \
               -d projectname="testdummy" \
               -d max_python="3.12" \
-              -d min_python="3.9" \
+              -d min_python="3.10" \
               -d nightly_deps="" \
-              -d related_projects=""
+              -d related_projects="ScippNeutron"  # Just to test the list.
       - run: git init  # ``setuptools`` complains if it is not a git repository.
         working-directory: ${{ env.DUMMYPROJECTPATH }}
       - run: sed -i '/dependencies = \[/a\    "numpy"' pyproject.toml
         working-directory: ${{ env.DUMMYPROJECTPATH }}
       - run: tox -e deps
         working-directory: ${{ env.DUMMYPROJECTPATH }}
-      - run: tox -e py39
+      - run: tox -e py310
         working-directory: ${{ env.DUMMYPROJECTPATH }}
-      - run: tox -e static
+      - run: git add -A && tox -e static  # Files should be added to be checked
         working-directory: ${{ env.DUMMYPROJECTPATH }}
       - run: tox -e docs
         working-directory: ${{ env.DUMMYPROJECTPATH }}

--- a/template/docs/conf.py.jinja
+++ b/template/docs/conf.py.jinja
@@ -164,9 +164,8 @@ html_theme_options = {
     },
     "external_links": [
 {% for link in related_projects.replace(' ', '').split(',')|sort -%}
-        {"name": "{{ link }}", "url": "https://{{orgname}}.github.io{% if link == 'Scipp' %}{% else %}/{{ link|lower }}{% endif %}"},
-{% endfor %}
-    ],
+{% raw %}        {% endraw %}{"name": "{{ link }}", "url": "https://{{orgname}}.github.ioz{% if link == 'Scipp' %}{% else %}/{{ link|lower }}{% endif %}"},
+{% endfor %}    ],
     "icon_links": [
         {
             "name": "GitHub",


### PR DESCRIPTION
# CI
- Updated python version to `3.10`
- Add files so that `tox -e static` can see the files ( they were not checked since they were not seen by git )
- Add more related project option to make the example more realistic

# docs/conf.py template
- Updated the jinja syntax to fix the ruff error as it renders.