### PR TITLE
Use new pre-commit-hook for windows filenames

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,10 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-illegal-windows-names
       - id: check-json
         exclude: asv.conf.json
       - id: check-merge-conflict

--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -1,8 +1,10 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-illegal-windows-names
       - id: check-json
         exclude: asv.conf.json
       - id: check-merge-conflict


### PR DESCRIPTION
`pre-commit-hooks` v5 has recently been released. It added [check-illegal-windows-names](https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#check-illegal-windows-names) which sounds useful since we deploy to Windows but rarely test on it. I also added [check-case-conflict](https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#check-case-conflict) for the same reason even though it already existed in older versions.