### PR TITLE
Use actionlint pre-commit hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,14 +35,15 @@ jobs:
         with:
           python-version: '3.10'
       - run: pip install -r requirements/ci.txt
-      - run: copier copy ./ ${DUMMYPROJECTPATH} \
-               -l \
-               -d description="Dummy project to test the template." \
-               -d projectname="testdummy" \
-               -d max_python="3.12" \
-               -d min_python="3.10" \
-               -d nightly_deps="" \
-               -d related_projects="ScippNeutron"  # Just to test the list.
+      - run: |
+            copier copy ./ "${DUMMYPROJECTPATH}" \
+              -l \
+              -d description="Dummy project to test the template." \
+              -d projectname="testdummy" \
+              -d max_python="3.12" \
+              -d min_python="3.10" \
+              -d nightly_deps="" \
+              -d related_projects="ScippNeutron"  # Just to test the list.
       - run: git init  # ``setuptools`` complains if it is not a git repository.
         working-directory: ${{ env.DUMMYPROJECTPATH }}
       - run: sed -i '/dependencies = \[/a\    "numpy"' pyproject.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,15 +35,14 @@ jobs:
         with:
           python-version: '3.10'
       - run: pip install -r requirements/ci.txt
-      - run: |
-            copier copy ./ ${DUMMYPROJECTPATH} \
-              -l \
-              -d description="Dummy project to test the template." \
-              -d projectname="testdummy" \
-              -d max_python="3.12" \
-              -d min_python="3.10" \
-              -d nightly_deps="" \
-              -d related_projects="ScippNeutron"  # Just to test the list.
+      - run: copier copy ./ ${DUMMYPROJECTPATH} \
+               -l \
+               -d description="Dummy project to test the template." \
+               -d projectname="testdummy" \
+               -d max_python="3.12" \
+               -d min_python="3.10" \
+               -d nightly_deps="" \
+               -d related_projects="ScippNeutron"  # Just to test the list.
       - run: git init  # ``setuptools`` complains if it is not a git repository.
         working-directory: ${{ env.DUMMYPROJECTPATH }}
       - run: sed -i '/dependencies = \[/a\    "numpy"' pyproject.toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,5 @@ repos:
     rev: v1.7.3
     hooks:
       - id: actionlint
+        # Disable because of false-positive SC2046
+        args: ["-shellcheck="]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,7 @@ repos:
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
       - id: text-unicode-replacement-char
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.3
+    hooks:
+      - id: actionlint

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Get Python version for other CI jobs
         id: vars
         run: |
-          echo "min_python=$(cat .github/workflows/python-version-ci)" >> $GITHUB_OUTPUT
-          echo "min_tox_env=py$(cat .github/workflows/python-version-ci | sed 's/\.//g')" >> $GITHUB_OUTPUT
+          echo "min_python=$(< .github/workflows/python-version-ci)" >> "$GITHUB_OUTPUT"
+          echo "min_tox_env=py$(sed 's/\.//g' < .github/workflows/python-version-ci)" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-python@v5
         with:
           python-version-file: '.github/workflows/python-version-ci'

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -53,6 +53,6 @@ jobs:
     uses: ./.github/workflows/docs.yml
     with:
       publish: false
-      linkcheck: ${{ contains(matrix.variant.os, 'ubuntu') && github.ref == 'refs/heads/main' }}
+      linkcheck: github.ref == 'refs/heads/main' }}
       branch: ${{ github.head_ref == '' && github.ref_name || github.head_ref }}
     secrets: inherit

--- a/template/.github/workflows/docs.yml
+++ b/template/.github/workflows/docs.yml
@@ -58,7 +58,7 @@ jobs:
           python-version-file: '.github/workflows/python-version-ci'
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -r requirements/ci.txt
-      - run: tox -e releasedocs -- ${VERSION}
+      - run: tox -e releasedocs -- "${VERSION}"
         if: ${{ inputs.version != '' }}
       - run: tox -e docs
         if: ${{ inputs.version == '' }}

--- a/template/.github/workflows/nightly_at_main.yml
+++ b/template/.github/workflows/nightly_at_main.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Get Python version for other CI jobs
         id: vars
-        run: echo "min_python=$(cat .github/workflows/python-version-ci)" >> $GITHUB_OUTPUT
+        run: echo "min_python=$(< .github/workflows/python-version-ci)" >> "$GITHUB_OUTPUT"
 
   tests:
     name: Tests

--- a/template/.github/workflows/nightly_at_release.yml
+++ b/template/.github/workflows/nightly_at_release.yml
@@ -18,10 +18,10 @@ jobs:
           fetch-depth: 0  # history required so we can determine latest release tag
       - name: Get last release tag from git
         id: release
-        run: echo "release_tag=$(git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*')" >> $GITHUB_OUTPUT
+        run: echo "release_tag=$(git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*')" >> "$GITHUB_OUTPUT"
       - name: Get Python version for other CI jobs
         id: vars
-        run: echo "min_python=$(cat .github/workflows/python-version-ci)" >> $GITHUB_OUTPUT
+        run: echo "min_python=$(cat .github/workflows/python-version-ci)" >> "$GITHUB_OUTPUT"
 
   tests:
     name: Tests

--- a/template/.github/workflows/unpinned.yml
+++ b/template/.github/workflows/unpinned.yml
@@ -18,10 +18,10 @@ jobs:
           fetch-depth: 0  # history required so we can determine latest release tag
       - name: Get last release tag from git
         id: release
-        run: echo "release_tag=$(git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*')" >> $GITHUB_OUTPUT
+        run: echo "release_tag=$(git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*')" >> "$GITHUB_OUTPUT"
       - name: Get Python version for other CI jobs
         id: vars
-        run: echo "min_python=$(cat .github/workflows/python-version-ci)" >> $GITHUB_OUTPUT
+        run: echo "min_python=$(cat .github/workflows/python-version-ci)" >> "$GITHUB_OUTPUT"
 
   tests:
     name: Tests

--- a/template/.github/workflows/{% if orgname == 'scipp' %}release.yml{% endif %}
+++ b/template/.github/workflows/{% if orgname == 'scipp' %}release.yml{% endif %}
@@ -85,7 +85,7 @@ jobs:
           create-args: >-
             anaconda-client
             python=3.11
-      - run: anaconda --token ${{ secrets.ANACONDATOKEN }} upload --user scipp --label main "$(ls conda-package-noarch/*.tar.bz2)"
+      - run: anaconda --token ${{ secrets.ANACONDATOKEN }} upload --user scipp --label main $(ls conda-package-noarch/*.tar.bz2)
 
   docs:
     needs: [upload_conda, upload_pypi]

--- a/template/.github/workflows/{% if orgname == 'scipp' %}release.yml{% endif %}
+++ b/template/.github/workflows/{% if orgname == 'scipp' %}release.yml{% endif %}
@@ -85,7 +85,7 @@ jobs:
           create-args: >-
             anaconda-client
             python=3.11
-      - run: anaconda --token ${{ secrets.ANACONDATOKEN }} upload --user scipp --label main $(ls conda-package-noarch/*.tar.bz2)
+      - run: anaconda --token ${{ secrets.ANACONDATOKEN }} upload --user scipp --label main "$(ls conda-package-noarch/*.tar.bz2)"
 
   docs:
     needs: [upload_conda, upload_pypi]

--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -46,3 +46,7 @@ repos:
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
       - id: text-unicode-replacement-char
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.3
+    hooks:
+      - id: actionlint

--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -50,3 +50,5 @@ repos:
     rev: v1.7.3
     hooks:
       - id: actionlint
+        # Disable because of false-positive SC2046
+        args: ["-shellcheck="]


### PR DESCRIPTION
Fixes #226

actionlint includes [ShellCheck](https://github.com/koalaman/shellcheck) which found a number of issues in our scripts. See individual comments for explanations of the changes.

Unfortunately, it seems that ShellCheck is only included when running actionlint in a docker container (the default on GH) or it needs to be installed separately on a local machine. Without it, there can be a discrepancy between CI and local builds.