### PR TITLE
Use scipp from pypi index instead of github url for nightlies

### DIFF
--- a/template/requirements/make_base.py
+++ b/template/requirements/make_base.py
@@ -1,4 +1,3 @@
-import sys
 from argparse import ArgumentParser
 from pathlib import Path
 
@@ -58,6 +57,9 @@ def as_nightly(repo: str) -> str:
     else:
         org = "scipp"
     if repo == "scipp":
+        # With the standard pip resolver index-url takes precedence over
+        # extra-index-url but with uv it's reversed, so if we move to tox-uv
+        # this needs to be reversed.
         return (
             "scipp\n"
             "--index-url=https://pypi.anaconda.org/scipp-nightly-wheels/simple/\n"

--- a/template/requirements/make_base.py
+++ b/template/requirements/make_base.py
@@ -58,11 +58,12 @@ def as_nightly(repo: str) -> str:
     else:
         org = "scipp"
     if repo == "scipp":
-        version = f"cp{sys.version_info.major}{sys.version_info.minor}"
-        base = "https://github.com/scipp/scipp/releases/download/nightly/scipp-nightly"
-        suffix = "manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-        prefix = "scipp @ "
-        return prefix + "-".join([base, version, version, suffix])
+        return (
+            "scipp\n"
+            "--index-url=https://pypi.anaconda.org/scipp-nightly-wheels/simple/\n"
+            "--extra-index-url=https://pypi.org/simple\n"
+            "--pre"
+        )
     return f"{repo} @ git+https://github.com/{org}/{repo}@main"
 
 

--- a/template/tox.ini.jinja
+++ b/template/tox.ini.jinja
@@ -10,6 +10,9 @@ commands = pytest {posargs}
 
 [testenv:nightly]
 deps = -r requirements/nightly.txt
+setenv =
+  PIP_INDEX_URL = https://pypi.anaconda.org/scipp-nightly-wheels/simple
+  PIP_EXTRA_INDEX_URL = https://pypi.org/simple
 commands = pytest {posargs}
 
 [testenv:unpinned]


### PR DESCRIPTION
Tested in https://github.com/scipp/essreflectometry/pull/104