### PR TITLE
Update ruff and make RUF022 fixable

### DIFF
--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         args: [ "--drop-empty-cells",
                 "--extra-keys 'metadata.language_info.version cell.metadata.jp-MarkdownHeadingCollapsed cell.metadata.pycharm'" ]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.8.0
     hooks:
       - id: ruff
         args: [ --fix ]

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -75,7 +75,7 @@ ignore = [
     # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
     "COM812", "COM819", "D206", "D300", "E111", "E114", "E117", "ISC001", "ISC002", "Q000", "Q001", "Q002", "Q003", "W191",
 ]
-fixable = ["B010", "I001", "PT001"]
+fixable = ["B010", "I001", "PT001", "RUF022"]
 isort.known-first-party = ["{% if namespace_package %}{{namespace_package}}.{% endif %}{{ projectname.removeprefix(namespace_package) }}"]
 pydocstyle.convention = "numpy"
 


### PR DESCRIPTION
We came across `RUF022` from using a newer version of ruff outside of pre-commit. So Let's update.

[RUF022](https://docs.astral.sh/ruff/rules/unsorted-dunder-all/) should be safe for us and we soft `__all__` manually anyway.