### PR TITLE
MAINT: Use --annotate-index while running pip-compile to use anaconda pypi index

### DIFF
--- a/template/tox.ini.jinja
+++ b/template/tox.ini.jinja
@@ -67,4 +67,4 @@ deps =
 skip_install = true
 changedir = requirements
 commands = python ./make_base.py{% if nightly_deps %} --nightly {{nightly_deps}}{% endif %}
-           pip-compile-multi -d . --backtracking
+           pip-compile-multi -d . --backtracking --annotate-index


### PR DESCRIPTION
This should fix https://github.com/scipp/copier_template/issues/239