### PR TITLE
Properly ignore uv.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ dist
 
 venv
 .venv
-uv.lock  # we lock dependencies with pip-compile, not uv
+# we lock dependencies with pip-compile, not uv
+uv.lock
 
 *.sw?
 compile_commands.json

--- a/template/.gitignore.jinja
+++ b/template/.gitignore.jinja
@@ -4,7 +4,8 @@ dist
 html
 .tox
 *.egg-info
-uv.lock  # we lock dependencies with pip-compile, not uv
+# we lock dependencies with pip-compile, not uv
+uv.lock
 
 *.sw?
 


### PR DESCRIPTION
Looks like comments are not allowed after the file name. This went wrong in https://github.com/scipp/scippneutron/pull/602