### PR TITLE
Add link to built docs as workflow annotation

### DIFF
--- a/template/.github/workflows/docs.yml
+++ b/template/.github/workflows/docs.yml
@@ -65,9 +65,11 @@ jobs:
       - run: tox -e linkcheck
         if: ${{ inputs.linkcheck }}
       - uses: actions/upload-artifact@v4
+        id: artifact-upload-step
         with:
           name: docs_html
           path: html/
+      - run: echo "::notice::https://remote-unzip.deno.dev/${{ github.repository }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}"
 
       - uses: JamesIves/github-pages-deploy-action@v4.7.2
         if: ${{ inputs.publish }}


### PR DESCRIPTION
This displays a url on the summary page of builds where we can quickly view the built docs online:
![Screenshot_20250221_095615](https://github.com/user-attachments/assets/3c4ed19f-8cd1-48bb-8bb1-1f10f239cbfb)
