### PR TITLE
Pin pip version to 24.2 to avoid absolute paths while resolving deps

### DIFF
--- a/template/tox.ini.jinja
+++ b/template/tox.ini.jinja
@@ -64,6 +64,8 @@ description = Update dependencies by running pip-compile-multi
 deps =
   pip-compile-multi
   tomli
+  # Avoid https://github.com/jazzband/pip-tools/issues/2131
+  pip==24.2
 skip_install = true
 changedir = requirements
 commands = python ./make_base.py{% if nightly_deps %} --nightly {{nightly_deps}}{% endif %}


### PR DESCRIPTION
This pops up in sciline https://github.com/scipp/sciline/pull/193 and https://github.com/scipp/copier_template/issues/242#issuecomment-2655873136