### PR TITLE
Improve docs landing page

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -24,7 +24,7 @@ min_python:
 max_python:
   type: str
   help: Maximum Python version that is known to work?
-year: 2024
+year: 2025
 nightly_deps:
   type: str
   help: |

--- a/template/docs/index.md.jinja
+++ b/template/docs/index.md.jinja
@@ -1,15 +1,48 @@
-# {{prettyname}}
+:::{image} _static/logo.svg
+:class: only-light
+:alt: {{prettyname}}
+:width: 60%
+:align: center
+:::
+:::{image} _static/logo-dark.svg
+:class: only-dark
+:alt: {{prettyname}}
+:width: 60%
+:align: center
+:::
 
-<span style="font-size:1.2em;font-style:italic;color:#5a5a5a">
+```{raw} html
+   <style>
+    .transparent {display: none; visibility: hidden;}
+    .transparent + a.headerlink {display: none; visibility: hidden;}
+   </style>
+```
+
+```{role} transparent
+```
+
+# {transparent}`{{prettyname}}`
+
+<span style="font-size:1.2em;font-style:italic;color:var(--pst-color-text-muted)">
   {{description}}
   </br></br>
 </span>
+
+:::{include} user-guide/installation.md
+:heading-offset: 1
+:::
+
+## Get in touch
+
+- If you have questions that are not answered by these documentation pages, ask on [discussions](https://github.com/{{orgname}}/{{projectname}}/discussions). Please include a self-contained reproducible example if possible.
+- Report bugs (including unclear, missing, or wrong documentation!), suggest features or view the source code [on GitHub](https://github.com/{{orgname}}/{{projectname}}).
 
 ```{toctree}
 ---
 hidden:
 ---
 
+user-guide/index
 api-reference/index
 developer/index
 about/index

--- a/template/docs/user-guide/index.md
+++ b/template/docs/user-guide/index.md
@@ -1,0 +1,9 @@
+# User Guide
+
+```{toctree}
+---
+maxdepth: 1
+---
+
+installation
+```

--- a/template/docs/user-guide/installation.md.jinja
+++ b/template/docs/user-guide/installation.md.jinja
@@ -1,0 +1,16 @@
+# Installation
+
+To install {{prettyname}} and all of its dependencies, use
+
+`````{tab-set}
+````{tab-item} pip
+```sh
+pip install {{projectname}}
+```
+````
+````{tab-item} conda
+```sh
+conda install -c conda-forge -c scipp {{projectname}}
+```
+````
+`````


### PR DESCRIPTION
Same as https://github.com/scipp/essdiffraction/pull/140

We need to be careful when deploying this to not remove existing content on the various docs pages. But we should get merge conflicts to help out out.