### PR TITLE
Update gh-action-pypi-publish

### DIFF
--- a/template/.github/workflows/{% if orgname == 'scipp' %}release.yml{% endif %}
+++ b/template/.github/workflows/{% if orgname == 'scipp' %}release.yml{% endif %}
@@ -68,7 +68,7 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v4
-      - uses: pypa/gh-action-pypi-publish@v1.8.14
+      - uses: pypa/gh-action-pypi-publish@v1.12.4
 
   upload_conda:
     name: Deploy Conda


### PR DESCRIPTION
Needs to be updated to use twine>6 which is required for uploading wheels.

Tried to make a release of esspolarization and the wheel preparation failed https://github.com/scipp/esspolarization/actions/runs/14079796810/job/39430093488