### PR TITLE
Revert "Support PEP 639"

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools>=77",
+  "setuptools>=68",
   "setuptools_scm[toml]>=8.0",
 ]
 build-backend = "setuptools.build_meta"
@@ -9,11 +9,11 @@ build-backend = "setuptools.build_meta"
 name = "{{projectname}}"
 description = "{{description}}"
 authors = [{ name = "Scipp contributors" }]
-license = "BSD-3-Clause"
-license-files = ["LICENSE"]
+license = { file = "LICENSE" }
 readme = "README.md"
 classifiers = [
     "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: BSD License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Reverts scipp/copier_template#249

This requires setuptools >= 77 which is not available on conda yet. (See https://github.com/conda-forge/setuptools-feedstock/pulls)