### PR TITLE
Center align the description text in docs index

### DIFF
--- a/template/docs/index.md.jinja
+++ b/template/docs/index.md.jinja
@@ -23,10 +23,10 @@
 
 # {transparent}`{{prettyname}}`
 
-<span style="font-size:1.2em;font-style:italic;color:var(--pst-color-text-muted)">
+<div style="font-size:1.2em;font-style:italic;color:var(--pst-color-text-muted);text-align:center;">
   {{description}}
   </br></br>
-</span>
+</div>
 
 :::{include} user-guide/installation.md
 :heading-offset: 1


### PR DESCRIPTION
Before:
![Screenshot_20250505_100818](https://github.com/user-attachments/assets/8cf8ab10-2a91-488c-ad0a-1a27f3b80605)

After:
![Screenshot_20250505_100808](https://github.com/user-attachments/assets/e2665324-00bd-4e4a-b714-52b11f116e37)

