### PR TITLE
Do not spellcheck SVG

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,8 @@ repos:
     hooks:
       - id: codespell
         args: [--ignore-words=.codespell-ignore]
+        exclude_types:
+          - svg
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:

--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -36,6 +36,8 @@ repos:
       - id: codespell
         additional_dependencies:
           - tomli
+        exclude_types:
+          - svg
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:


### PR DESCRIPTION
SVG files can contain some markup text that trips up the spellchecker. This is unfortunate because there can also be genuine text in SVG that we would want to check. But I think that is too rare to deal with the many false positives.