### PR TITLE
Change URL of license

### DIFF
--- a/template/docs/about/index.md.jinja
+++ b/template/docs/about/index.md.jinja
@@ -2,7 +2,7 @@
 
 ## Development
 
-{{prettyname}} is an open source project by the [European Spallation Source ERIC](https://europeanspallationsource.se/) (ESS).
+{{prettyname}} is an open source project by the [European Spallation Source ERIC](https://ess.eu/) (ESS).
 
 ## License
 

--- a/template/docs/about/index.md.jinja
+++ b/template/docs/about/index.md.jinja
@@ -6,7 +6,7 @@
 
 ## License
 
-{{prettyname}} is available as open source under the [BSD-3 license](https://opensource.org/licenses/BSD-3-Clause).
+{{prettyname}} is available as open source under the [BSD-3 license](https://opensource.org/license/BSD-3-Clause).
 
 ## Citing {{prettyname}}
 


### PR DESCRIPTION
Not strictly necessary but the previous one permanently redirects to the new one.