### PR TITLE
Use autodoc-pydantic

### DIFF
--- a/template/docs/conf.py.jinja
+++ b/template/docs/conf.py.jinja
@@ -32,6 +32,7 @@ extensions = [
     'sphinx_autodoc_typehints',
     'sphinx_copybutton',
     'sphinx_design',
+    'sphinxcontrib.autodoc_pydantic',
     'nbsphinx',
     'myst_parser',
 ]

--- a/template/requirements/docs.in
+++ b/template/requirements/docs.in
@@ -1,4 +1,5 @@
 -r base.in
+autodoc-pydantic
 ipykernel
 ipython!=8.7.0  # Breaks syntax highlighting in Jupyter code cells.
 myst-parser


### PR DESCRIPTION
This will be needed once we roll out #259 because sphinx processes the doctrings of `pydantic.BaseModel.__init__` in the models in ScippNeutron. Those models are re-exported as domain types in technique packages. And the docstrings contain invalid rst syntax (they use markdown). This extension hides the base methods and so we don't have that problem. As a bonus, the rendered output is more useful.