### PR TITLE
Disable linkcheck for dx.doi.org

### DIFF
--- a/template/docs/conf.py.jinja
+++ b/template/docs/conf.py.jinja
@@ -265,5 +265,6 @@ linkcheck_ignore = [
     r'https?://github\.com/.*?/blob/[a-f0-9]+/.+?#',
     # Linkcheck seems to be denied access by some DOI resolvers.
     # Since DOIs are supposed to be permanent, we don't need to check them.'
-    r'https://doi\.org/',
+    r'https?://doi\.org/',
+    r'https?://dx\.doi\.org/',
 ]


### PR DESCRIPTION
This fixes an error in ESSreduce: #260