### PR TITLE
Pin dependencies for package-test

### DIFF
--- a/template/.github/workflows/test.yml
+++ b/template/.github/workflows/test.yml
@@ -14,6 +14,9 @@ on:
       pip-recipe:
         default: 'requirements/ci.txt'
         type: string
+      base-deps:
+        default: 'requirements/base.txt'
+        type: string
       coverage-report:
         default: false
         type: boolean
@@ -32,6 +35,9 @@ on:
         type: string
       pip-recipe:
         default: 'requirements/ci.txt'
+        type: string
+      base-deps:
+        default: 'requirements/base.txt'
         type: string
       coverage-report:
         default: false
@@ -52,6 +58,7 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
       - run: python -m pip install --upgrade pip
+      - run: python -m pip install -r ${{ inputs.base-deps }}
       - run: python -m pip install .
       - run: python tests/package_test.py
         name: Run package tests


### PR DESCRIPTION
Before this PR, we were doing a simple `pip install .` which would fetch the latest version of any dependency.
Now we install `base.txt` beforehand, so that the dependencies are already installed, and consistent with the other test environment.