### PR TITLE
Lower bound of pytest in the template.

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -36,7 +36,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 test = [
-    "pytest",
+    "pytest>=8.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Pytest lower bound was important for the nested warning catch tests in NMX.

> https://github.com/scipp/essnmx/pull/192

It seems like most of our projects have lower pin of pytest anyway so I thought it could be in the template as well.