### PR TITLE
Change basetest dependency file from .txt to .in for unpinned run

### DIFF
--- a/template/tox.ini.jinja
+++ b/template/tox.ini.jinja
@@ -18,7 +18,7 @@ commands = pytest {posargs}
 [testenv:unpinned]
 description = Test with unpinned dependencies, as a user would install now.
 deps =
-  -r requirements/basetest.txt
+  -r requirements/basetest.in
   {{projectname}}
 commands = pytest {posargs}
 


### PR DESCRIPTION
Versions should be unpinned for the unpinned run?